### PR TITLE
Fix sidebar navigation arrow

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -138,4 +138,8 @@
   @media (min-width: breakpoint.$desktop) {
     display: flex;
   }
+
+  &.collapsed img {
+    transform: rotate(180deg);
+  }
 }

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -90,7 +90,10 @@ export function SidebarNavigation() {
               iconSrc="/icons/arrow-left.svg"
               isCollapsed={isSidebarCollapsed}
               onClick={() => toggleSidebar()}
-              className={styles.collapseMenuItem}
+              className={classNames(
+                styles.collapseMenuItem,
+                isSidebarCollapsed && styles.collapsed,
+              )}
             />
           </ul>
         </nav>


### PR DESCRIPTION
When the sidebar navigation is collapsed, the arrow of the “Collapse” button now points to the right.